### PR TITLE
Image path validation

### DIFF
--- a/src/backend/routes/envi.py
+++ b/src/backend/routes/envi.py
@@ -11,8 +11,11 @@ router = APIRouter(
 
 @router.get("/")
 def read_envi(path, band, rotation=0, reshape=[None, None]):
+  if hiper.hiper_image_validation_path(path) == False: return {"error": "Image not found", "code": 404}
+  
   reshape = json.loads(reshape)
-  img, shape, resize_ratio= hiper.read_envi(path, band, rotation, reshape)
+  res = hiper.read_envi(path, band, rotation, reshape)
+  img, shape, resize_ratio = res
   return StreamingResponse(img, media_type="image/png", headers={"X-shape": ",".join([str(i) for i in shape]), "X-resize": str(resize_ratio)})
   
 @router.get("/info/")

--- a/src/backend/routes/envi.py
+++ b/src/backend/routes/envi.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, Response
 from services import hiper
 import json
 
@@ -11,7 +11,8 @@ router = APIRouter(
 
 @router.get("/")
 def read_envi(path, band, rotation=0, reshape=[None, None]):
-  if hiper.hiper_image_validation_path(path) == False: return {"error": "Image not found", "code": 404}
+  if not hiper.hiper_image_validation_path(path):
+    return Response(status_code=404, content="Image not found")
   
   reshape = json.loads(reshape)
   res = hiper.read_envi(path, band, rotation, reshape)

--- a/src/backend/services/hiper.py
+++ b/src/backend/services/hiper.py
@@ -168,3 +168,11 @@ def hdr_info_file(path):
   metadata['description'] = metadata['description'].replace('{', '').replace('}', '')
   file.close()
   return metadata
+
+def hiper_image_validation_path(path):
+  path = path.replace('"', "")
+  image = path.replace('.hdr', "")
+  if not os.path.exists(image) or not os.path.exists(path):
+    return False
+  else:
+    return True

--- a/src/components/ImageViewer.jsx
+++ b/src/components/ImageViewer.jsx
@@ -41,8 +41,8 @@ export default function ImageViewer({loader, setLoader}) {
     try{
       
       const {width, height} = getElementShape("img_cont")
-      const {url, shape, resize} = await getImgUrl({path: hiperImgValues.path, rotation: toolsValues.rotationValue, reshape:[width,height]})
-      
+      const {url, shape, resize, error} = await getImgUrl({path: hiperImgValues.path, rotation: toolsValues.rotationValue, reshape:[width,height]})
+      if (error) return setLoader(false)
       setHiperImgValues({...hiperImgValues, url: url, shape: shape, resize: resize})
       
       let slider = document.getElementById("band_slider")
@@ -141,7 +141,8 @@ export default function ImageViewer({loader, setLoader}) {
   const onResizeCanvas = async (width, height) => {
     if (hiperImgValues.path == "") return
     setLoader(true)
-    const {url, shape, resize} = await getImgUrl({path: hiperImgValues.path, rotation: toolsValues.rotationValue, reshape:[width,height]})
+    const {url, shape, resize, error} = await getImgUrl({path: hiperImgValues.path, rotation: toolsValues.rotationValue, reshape:[width,height]})
+    if (error) return setLoader(false)
     setHiperImgValues({...hiperImgValues, url: url, shape: shape, resize: resize})
     setLoader(false)
   }

--- a/src/components/ImageViewer.jsx
+++ b/src/components/ImageViewer.jsx
@@ -139,6 +139,7 @@ export default function ImageViewer({loader, setLoader}) {
   }
 
   const onResizeCanvas = async (width, height) => {
+    if (hiperImgValues.path == "") return
     setLoader(true)
     const {url, shape, resize} = await getImgUrl({path: hiperImgValues.path, rotation: toolsValues.rotationValue, reshape:[width,height]})
     setHiperImgValues({...hiperImgValues, url: url, shape: shape, resize: resize})

--- a/src/components/ImageViewer.jsx
+++ b/src/components/ImageViewer.jsx
@@ -117,14 +117,7 @@ export default function ImageViewer({loader, setLoader}) {
         console.error(`Error: ${error} at x: ${x}, y: ${y}`);
       }
     }else if(toolsValues.pixelCheck && toolsValues.rotationValue !=0 ){
-      toast.error(`Rotación debe ser igual a 0 para realizar esta operación`,{
-        style: {
-          borderRadius: '10px',
-          background: '#333',
-          color: '#fff',
-        }
-      })
-
+      toast.error(`Rotación debe ser igual a 0 para realizar esta operación`)
     }
 
     if (toolsValues.cutCheck){

--- a/src/components/LeftBar.jsx
+++ b/src/components/LeftBar.jsx
@@ -5,6 +5,8 @@ import { RiImageAddFill } from "react-icons/ri";
 import { open } from "@tauri-apps/api/dialog";
 import { HiperImgContext } from '../context/hiperImg.jsx';
 import { ToolsContext } from '../context/tools.jsx';
+import { checkHiperPath } from '../services/utils.js';
+import toast from 'react-hot-toast';
 
 export default function LeftBar() {
   const {hiperImgValues, setHiperImgValues} = useContext(HiperImgContext)
@@ -21,7 +23,8 @@ export default function LeftBar() {
       ],
     })
     if (!selected) return
-
+    if (!await checkHiperPath(selected)) return toast.error("Imagen no encontrada\nRevise que la imagen y su archivo .hdr estén ubicados en la misma carpeta")
+    
     setHiperImgValues(prev => ({...prev, path: selected}))
     setToolsValues({...toolsValues, rotationValue:0})
   }

--- a/src/components/tools/InputRotation.jsx
+++ b/src/components/tools/InputRotation.jsx
@@ -70,7 +70,8 @@ export default function InputRotation({ setLoader }) {
     setLoader(true)
     setToolsValues({...toolsValues, rotationValue: rotation})
     const {width, height} = getElementShape("img_cont")
-    const {url, shape, resize} = await getImgUrl({path: hiperImgValues.path, channel: hiperImgValues.channel, rotation: rotation, reshape:[width,height]})
+    const {url, shape, resize, error} = await getImgUrl({path: hiperImgValues.path, channel: hiperImgValues.channel, rotation: rotation, reshape:[width,height]})
+    if (error) return setLoader(false)
     setHiperImgValues({...hiperImgValues, url: url, shape: shape, resize: resize})
     setLoader(false)
   }

--- a/src/components/tools/InputRotation.jsx
+++ b/src/components/tools/InputRotation.jsx
@@ -66,9 +66,9 @@ export default function InputRotation({ setLoader }) {
   }
 
   let rotateImage = async () => {
+    if (hiperImgValues.path == "") return
     setLoader(true)
     setToolsValues({...toolsValues, rotationValue: rotation})
-    if (hiperImgValues.path == "") return
     const {width, height} = getElementShape("img_cont")
     const {url, shape, resize} = await getImgUrl({path: hiperImgValues.path, channel: hiperImgValues.channel, rotation: rotation, reshape:[width,height]})
     setHiperImgValues({...hiperImgValues, url: url, shape: shape, resize: resize})

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,7 +11,13 @@ ReactDOM.createRoot(document.getElementById("root")).render(
     <ToolsProvider>
       <OptionDialogProvider>
         <App />
-        <Toaster position="bottom-center"/>
+        <Toaster position="bottom-center" toastOptions={{
+          style: {
+            borderRadius: '10px',
+            background: '#333',
+            color: '#fff',
+          }
+        }}/>
       </OptionDialogProvider>
     </ToolsProvider>
   </HiperImgProvider>

--- a/src/services/hiper.js
+++ b/src/services/hiper.js
@@ -1,4 +1,4 @@
-
+import toast from 'react-hot-toast';
 const BACKEND_URL = "http://localhost:8008/envi"
 
 export let getPixelInfo = async ({path, x, y}) =>{
@@ -15,7 +15,18 @@ export let getPixelInfo = async ({path, x, y}) =>{
 export let getImgUrl = async ({path,channel=0,rotation=0, reshape=[null, null]}) =>{
   reshape = JSON.stringify(reshape)
   const response = await fetch(`${BACKEND_URL}/?path="${path}"&band=${channel}&rotation=${rotation}&reshape=${reshape}`)
-  
+
+  if (response.status == 404) {
+    toast.error("Imagen no encontrada\nrevise la imagen y su archivo .hdr estén ubicados en la misma carpeta")
+
+    return{
+      url: null,
+      shape: null,
+      resize: null,
+      error: "Image not found"
+    }
+  }
+
   return {
     url: response.url,
     shape: response.headers.get('X-shape').split(','),

--- a/src/services/hiper.js
+++ b/src/services/hiper.js
@@ -17,7 +17,7 @@ export let getImgUrl = async ({path,channel=0,rotation=0, reshape=[null, null]})
   const response = await fetch(`${BACKEND_URL}/?path="${path}"&band=${channel}&rotation=${rotation}&reshape=${reshape}`)
 
   if (response.status == 404) {
-    toast.error("Imagen no encontrada\nrevise la imagen y su archivo .hdr estén ubicados en la misma carpeta")
+    toast.error("Imagen no encontrada\nRevise que la imagen y su archivo .hdr estén ubicados en la misma carpeta")
 
     return{
       url: null,

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -1,5 +1,18 @@
+import { exists } from '@tauri-apps/api/fs'
+
 export function getElementShape(id){
   const element = document.getElementById(id)
   const rect = element.getBoundingClientRect()
   return {x: rect.x, y: rect.y, width: rect.width, height: rect.height}
+}
+
+export async function checkHiperPath(path){
+  if (path == null) return false
+  if (path.length == 0) return false
+  const image = path.replace('.hdr', '')
+  
+  if (!await exists(image) || !await exists(path)){
+    return false
+  }
+  return true
 }


### PR DESCRIPTION
Se agrega validación de archivos hiperespectrales en backend y frontend, aplicando un toast para informar al usuario del error.
![image](https://github.com/user-attachments/assets/2107cc45-951a-4e3e-800c-5a2dc05a8105)
Además se agrega estilos generales al toast, evitando que se tengan que configurar los estilos cada vez que se le llame.

Se agrega validación de rutas vacías para evitar peticiones apenas iniciar la aplicación.