### PR TITLE
Optimize image reading

### DIFF
--- a/src/backend/services/hiper.py
+++ b/src/backend/services/hiper.py
@@ -8,13 +8,11 @@ import services.transformation as tf
 import os
 import pandas as pd
 import utils as ut
+import cv2
 
 def read_envi(path, band, rotation=0, reshape=[None, None]):
   path = path.replace('"', "")
-  image = path.replace('.hdr', "")
-  file = path
-  image = envi.open(file, image)
-  
+  image = envi.open(path, path.replace('.hdr', ""))
   if int(band) > image.shape[2]:
     return "error"
   
@@ -22,17 +20,12 @@ def read_envi(path, band, rotation=0, reshape=[None, None]):
   resize_ratio = 1
   if reshape != [None, None]:
     new_width, new_height, resize_ratio = ut.get_new_size(banda, int(reshape[0]), int(reshape[1]))
-    banda = ut.reshape_matrix(banda, new_width, new_height)
-  
+    banda = cv2.resize(banda, (new_width, new_height), interpolation = cv2.INTER_NEAREST)   
   banda = cv2.normalize(banda, None, 0, 255, cv2.NORM_MINMAX, dtype=cv2.CV_8U)
   if rotation != 0:
     banda = tf.rotate_matrix(banda, float(rotation) *-1)
-
-  img = Image.fromarray(banda)
-  buffered = BytesIO()
-  img.save(buffered, format="PNG")
-  buffered.seek(0)
-  return buffered, (banda.shape[0], banda.shape[1], image.shape[2]), resize_ratio
+  _, img_encoded = cv2.imencode('.png', banda)
+  return BytesIO(img_encoded.tobytes()), (banda.shape[0], banda.shape[1], image.shape[2]), resize_ratio
 
 def read_envi_info(path):
   path = path.replace('"', "")

--- a/src/backend/utils.py
+++ b/src/backend/utils.py
@@ -22,25 +22,6 @@ def cut_points_to_array(cut_points):
             (math.floor(float(cut_points[1]['x'])), math.floor(float(cut_points[1]['y'])))]
   return points
 
-def reshape_matrix(matriz, nuevo_ancho, nuevo_alto):
-    # Obtiene las dimensiones originales
-    alto_original, ancho_original = matriz.shape
-    
-    # Crea una nueva matriz para almacenar los datos redimensionados
-    matriz_redimensionada = np.zeros((nuevo_alto, nuevo_ancho), dtype=matriz.dtype)
-    
-    # Calcula los factores de escala
-    factor_y = alto_original / nuevo_alto
-    factor_x = ancho_original / nuevo_ancho
-    
-    for i in range(nuevo_alto):
-        for j in range(nuevo_ancho):
-            # Encuentra las coordenadas correspondientes en la matriz original
-            x_original = int(j * factor_x)
-            y_original = int(i * factor_y)
-            matriz_redimensionada[i, j] = matriz[y_original, x_original]
-    
-    return matriz_redimensionada
 
 def get_new_size(image, ancho, alto):
   o_alto, o_ancho = image.shape


### PR DESCRIPTION
Se optimizo la lectura de imágenes hiperespectrales al guardar en un diccionario las matrices ya reescaladas de las imágenes y reutilizándolas en caso de que se vueva a hacer una petición de la misma banda, de una imagen ya cargada y de una forma ya pedida. Además se reemplazo el uso de funciones propias o de la librería pillow, por funciones de opencv mejores optimizadas.