### PR TITLE
Fix metadata reading

### DIFF
--- a/src/backend/classes/HiperImg.py
+++ b/src/backend/classes/HiperImg.py
@@ -32,7 +32,9 @@ class HiperImg:
       line = line.strip()
       if line == 'ENVI': continue
       if '=' in line:
-        key, value = line.split('=')
+        list_line = line.split('=')
+        key = list_line[0].strip()
+        value = '='.join(list_line[1:])
         metadata[key.strip()] = value.strip()
         past_key = key.strip()
       else:

--- a/src/backend/services/hiper.py
+++ b/src/backend/services/hiper.py
@@ -167,7 +167,9 @@ def hdr_info_file(path):
     line = line.strip()
     if line == 'ENVI': continue
     if '=' in line:
-      key, value = line.split('=')
+      list_line = line.split('=')
+      key = list_line[0].strip()
+      value = '='.join(list_line[1:])
       metadata[key.strip()] = value.strip()
       past_key = key.strip()
     else:


### PR DESCRIPTION
Se corrige error en la lectura de los metadatos de la imagen que surgía al separar una línea con más de un "=", ahora se separa la línea y la key siempre es el primer elemento de la lista y lo demás se vuelve a juntar, lo que permite que existan más de un "=" por línea y los datos se mantengan.