### PR TITLE
fix(backend): Fix cut point null

### DIFF
--- a/src/components/windows/Dialogs/ExportOptions.jsx
+++ b/src/components/windows/Dialogs/ExportOptions.jsx
@@ -44,7 +44,8 @@ export default function ExportOptions({setLoader}) {
         y: point.y / hiperImgValues.resize
       }
     })
-    const name_cutPoints = (resizedCutPoints == null) ? 'NONE' : Math.floor(resizedCutPoints[0].x) + '_' + Math.floor(resizedCutPoints[0].y)
+    
+    const name_cutPoints = (resizedCutPoints == null || resizedCutPoints[0] == null) ? 'NONE' : Math.floor(resizedCutPoints[0].x) + '_' + Math.floor(resizedCutPoints[0].y)
     const pathParts = hiperImgValues.path.split('\\');
     const fileName = pathParts.pop().split('.')[0] + '_rotated_'+toolsValues.rotationValue + '_cut_' + name_cutPoints;
     const path = pathParts.join('\\');


### PR DESCRIPTION
Se soluciona error al intentar exportar imágenes que no se hayan cortado, se añade extra verificación en caso de que el punto [0] sea null